### PR TITLE
Quick fix for exhausting animal cards #74 #78 #88

### DIFF
--- a/src/state/machines/turn.ts
+++ b/src/state/machines/turn.ts
@@ -321,6 +321,7 @@ export const TurnMachine = setup({
         });
         draft.turn.unlockedHabitat = true;
         draft.turn.playedCards = without(context.turn.playedCards, ...map(playedAnimals, "uid"));
+        draft.turn.exhaustedCards = concat(draft.turn.exhaustedCards, ...map(playedAnimals, "uid"));
 
         draft.stage = {
           eventType: "habitatUnlock",
@@ -871,7 +872,10 @@ export const TurnMachine = setup({
                 "user.click.player.hand.card": {
                   target: "pickingDestination",
                   actions: { type: "setAbilityTargetCard", params: ({ event: { card } }) => card },
-                  guard: { type: "ownsCard", params: ({ event: { card } }) => card.uid },
+                  guard: and([
+                    ({ context, event: { card } }) => TurnMachineGuards.notExhausted({ context }, card.uid),
+                    ({ context, event: { card } }) => TurnMachineGuards.ownsCard({ context }, card.uid),
+                  ]),
                 },
               },
             },

--- a/src/state/machines/turn.ts
+++ b/src/state/machines/turn.ts
@@ -182,7 +182,7 @@ export const TurnMachine = setup({
       }),
     ),
     cardToPlayerHand: assign(({ context }, card: Card) =>
-      produce(context, ({ players }) => {
+      produce(context, ({ players, turn }) => {
         const player = find(players, { uid: context.turn.player })!;
         const targetPlayer = players.find((player) => player.hand.some((handCard) => handCard.uid === card.uid));
 
@@ -190,6 +190,7 @@ export const TurnMachine = setup({
 
         player.hand = reject(player.hand, context.turn.currentAbility.targetCard);
         targetPlayer.hand.push(context.turn.currentAbility.targetCard);
+        turn.playedCards = without(context.turn.playedCards, context.turn.currentAbility.targetCard.uid);
       }),
     ),
     cardToElementDeck: assign(({ context }) =>

--- a/src/state/positioner.ts
+++ b/src/state/positioner.ts
@@ -596,16 +596,7 @@ export const positionPlayerCards = (gameState: GameState): GamePieceCoordsDict =
       .filter((card) => !exhaustedCards.includes(card.uid))
       .forEach((card: Card, cardIndex: number) => {
         const inPlay = playedCards.includes(card.uid);
-        const exhausted = exhaustedCards.includes(card.uid);
-        const offset = getPlayerCardOffset(
-          playerIndex,
-          cardIndex,
-          player.hand.length,
-          inPlay,
-          exhausted,
-          // turnState.player === player.uid,
-          true,
-        );
+        const offset = getPlayerCardOffset(playerIndex, cardIndex, player.hand.length, inPlay, false, true);
 
         acc[card.uid] = {
           position: {
@@ -625,13 +616,12 @@ export const positionPlayerCards = (gameState: GameState): GamePieceCoordsDict =
       .filter((card) => exhaustedCards.includes(card.uid))
       .forEach((card: Card, cardIndex: number) => {
         const inPlay = playedCards.includes(card.uid);
-        const exhausted = exhaustedCards.includes(card.uid);
         const offset = getPlayerCardOffset(
           playerIndex,
           cardIndex,
           player.hand.length - exhaustedCards.length,
           inPlay,
-          exhausted,
+          true,
           true,
         );
 


### PR DESCRIPTION
- Exhaust animal cards after using them to unlock habitat
- Minor cleanup in positioner
- Added guard to check if card is not exhausted when using move ability
- Tested #74 to ensure it works
- Remove moved card (move ability) from played cards