### PR TITLE
Improved ability UI and always check ele disaster #97 #98 #99

### DIFF
--- a/src/components/AbilityTiles.tsx
+++ b/src/components/AbilityTiles.tsx
@@ -3,6 +3,8 @@ import { abilityOffset } from "../constants/gameBoard";
 import { AbilityTile, Coordinate } from "@/state/types";
 import { useGameState } from "@/context/game-state/hook";
 import { useSRGBTexture } from "@/hooks/useSRGBTexture";
+import { useTexture } from "@react-three/drei";
+import { getHighlightTextureAssetPath } from "./utils";
 
 const AbilityTiles = ({
   xStart,
@@ -23,10 +25,11 @@ const AbilityTiles = ({
   isClickable: boolean;
   orientation?: "horizontal" | "vertical";
 }) => {
-  const { emit } = useGameState();
+  const { emit, state } = useGameState();
   const plusTexture = useSRGBTexture("/ecosfera_baltica/ability_plus.avif");
   const refreshTexture = useSRGBTexture("/ecosfera_baltica/ability_refresh.avif");
   const moveTexture = useSRGBTexture("/ecosfera_baltica/ability_move.avif");
+  const highlightTexture = useTexture(getHighlightTextureAssetPath(true));
 
   return abilities.map((ability, index) => (
     <GameElement
@@ -54,6 +57,12 @@ const AbilityTiles = ({
         color={ability.isUsed ? (canRefresh ? "white" : "#555") : "white"}
         map={ability.name === "move" ? moveTexture : ability.name === "plus" ? plusTexture : refreshTexture}
       />
+      {state.turn.currentAbility?.piece === ability && (
+        <mesh position={[0, 0, -0.1]}>
+          <circleGeometry args={[5, 32]} />
+          <meshBasicMaterial color="#1D86BC" transparent map={highlightTexture} />
+        </mesh>
+      )}
     </GameElement>
   ));
 };

--- a/src/components/CardAbilityTiles.tsx
+++ b/src/components/CardAbilityTiles.tsx
@@ -72,10 +72,12 @@ const CardAbilityTiles = ({ xStart, yStart, rotation = { x: 0, y: 0, z: 0 } }: C
                 : refreshTexture
         }
       />
-      <mesh position={[0, 0, -0.1]}>
-        <circleGeometry args={[5, 32]} />
-        <meshBasicMaterial color="#1D86BC" transparent map={highlightTexture} />
-      </mesh>
+      {state.turn.currentAbility?.name === ability && (
+        <mesh position={[0, 0, -0.1]}>
+          <circleGeometry args={[5, 32]} />
+          <meshBasicMaterial color="#1D86BC" transparent map={highlightTexture} />
+        </mesh>
+      )}
     </GameElement>
   ));
 };

--- a/src/components/Croupier.tsx
+++ b/src/components/Croupier.tsx
@@ -112,11 +112,11 @@ const Croupier = () => {
         <React.Fragment key={player.uid + "HUD"}>
           <GamePieceGroup gamePieceAppearance={uiState.deckPositions[`${player.uid}PlayerDeck`]}>
             <TextWithShadow
-              position={[-6, 10, 0]}
-              fontSize={5}
-              color="white"
+              position={[0, 12, 0]}
+              fontSize={2}
+              color="#FBF6E3"
               shadowColor="white"
-              anchorX="left"
+              anchorX="center"
               anchorY="bottom"
               textAlign="left"
             >

--- a/src/components/shapes/TextWithShadow.tsx
+++ b/src/components/shapes/TextWithShadow.tsx
@@ -1,5 +1,6 @@
 import { Text } from "@react-three/drei";
 import { ReactNode } from "react";
+import { MeshBasicMaterial } from "three";
 
 interface TextWithShadowProps {
   children: ReactNode;
@@ -15,15 +16,19 @@ const TextWithShadow = ({
   shadowColor = "lightgrey",
   position,
   ...props
-}: TextWithShadowProps) => (
-  <>
-    <Text {...props} color={shadowColor} position={[position[0] + 0.08, position[1] - 0.08, position[2]]}>
-      {children}
-    </Text>
-    <Text {...props} color={color} position={[position[0], position[1], position[2] + 0.05]}>
-      {children}
-    </Text>
-  </>
-);
+}: TextWithShadowProps) => {
+  const material = new MeshBasicMaterial({ toneMapped: false, color });
+
+  return (
+    <>
+      <Text {...props} color={shadowColor} position={[position[0] + 0.08, position[1] - 0.08, position[2]]}>
+        {children}
+      </Text>
+      <Text material={material} {...props} position={[position[0], position[1], position[2] + 0.05]}>
+        {children}
+      </Text>
+    </>
+  );
+};
 
 export default TextWithShadow;

--- a/src/state/machines/guards.ts
+++ b/src/state/machines/guards.ts
@@ -209,4 +209,8 @@ export const TurnMachineGuards = {
 
     return player.abilities.filter((ability) => ability.isUsed).length === 1;
   },
+
+  isMultiplayer: ({ context }: { context: GameState }) => {
+    return context.players.length > 1;
+  },
 };


### PR DESCRIPTION
- Improved ability UI by using highlighting to indicate active ability
- Clicking on ability tokens while in a card ability now allows you to select another ability
- Always check for elemental disaster condition instead of at the end of the turn
- Fixed bug where selecting a disaster card during a move ability bricks a single player game. Now disaster cards cannot be selecting when using a move ability in a single player game
- Aligned player name UI with Figma designs