### PR TITLE
Expansion cards using command bar #162

### DIFF
--- a/src/components/Croupier.tsx
+++ b/src/components/Croupier.tsx
@@ -189,6 +189,7 @@ const Croupier = () => {
             gameState.stage?.effect?.includes(habitatTile.uid) && gameState.stage.eventType !== "gameWin"
           }
           isAcquired={habitatTile.isAcquired}
+          onClick={emit.habitatTileClick(habitatTile.name)}
         />
       ))}
 

--- a/src/components/Policies/PolicyCard.tsx
+++ b/src/components/Policies/PolicyCard.tsx
@@ -39,7 +39,7 @@ const PolicyCard = ({
           )}
         >
           <h1 className="font-bold">{uiStrings[cardName].name}</h1>
-          <p className="text-sm font-light">{uiStrings[cardName].description}</p>
+          <p className="text-xs font-light">{uiStrings[cardName].description}</p>
           {!isActive && allowActivation && (
             <div className="flex w-full items-center justify-between space-x-2">
               <Button className="flex-1" onClick={onClick}>

--- a/src/decks/ecosfera-baltica.deck.json
+++ b/src/decks/ecosfera-baltica.deck.json
@@ -170,6 +170,26 @@
       "effect": "positive",
       "theme": "eutro",
       "usage": "permanent"
+    },
+    "Migratory barrier removal": {
+      "effect": "positive",
+      "theme": "restore",
+      "usage": "single"
+    },
+    "Fishing gear regulation": {
+      "effect": "positive",
+      "theme": "fishing",
+      "usage": "single"
+    },
+    "Recycling and waste disposal": {
+      "effect": "positive",
+      "theme": "litter",
+      "usage": "single"
+    },
+    "Green energy": {
+      "effect": "dual",
+      "theme": "msp",
+      "usage": "single"
     }
   },
   "plants": {

--- a/src/decks/schema.ts
+++ b/src/decks/schema.ts
@@ -55,6 +55,9 @@ const policyThemeSchema = z.enum([
   "extractionOfSpecies",
   "restore",
   "noise",
+  "fishing",
+  "litter",
+  "msp",
   "N/A",
 ]);
 const policyUsageSchema = z.enum(["single", "permanent"]);

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -78,6 +78,27 @@
       "improvedNutrientRetention": {
         "name": "Improved nutrient retention in agriculture",
         "description": "All producer cards requires one nutrient less for the rest of the game."
+      },
+      "migratoryBarrierRemoval": {
+        "name": "Migratory barrier removal",
+        "description": "Take one fish or bird card from the market and add it to any players hand.",
+        "targetCommandBarText": "Pick a fish or bird card from the market",
+        "destinationCommandBarText": "Pick a player's hand to move your chosen card to"
+      },
+      "fishingGearRegulation": {
+        "name": "Fishing gear regulation",
+        "description": "Add all cards in the market which have a mud symbol to any players hand.",
+        "commandBarText": "Pick a player's hand to move all the mud species to"
+      },
+      "recyclingAndWasteDisposal": {
+        "name": "Recycling and waste disposal",
+        "description": "Remove two human activity cards from the hand(s) of any player(s) and replace the cards with cards from the player(s) deck(s).",
+        "commandBarText": "Pick a disaster card to discard from any player's hand"
+      },
+      "greenEnergy": {
+        "name": "Green energy",
+        "description": "If coastal, hard- or soft bottom habitats have already been restored when this card is lifted, add an impact tile. If none of the above habitats have been restored prior to lifting this card, choose one of these habitats to immediately restore.",
+        "commandBarText": "Choose either the Rock or Mud habitat to unlock"
       }
     }
   },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -82,8 +82,8 @@
       "migratoryBarrierRemoval": {
         "name": "Migratory barrier removal",
         "description": "Take one fish or bird card from the market and add it to any players hand.",
-        "targetCommandBarText": "Pick a fish or bird card from the market",
-        "destinationCommandBarText": "Pick a player's hand to move your chosen card to"
+        "pickSpeciesCommandBarText": "Pick a fish or bird card from the market",
+        "pickPlayerCommandBarText": "Pick a player's hand to move your chosen card to"
       },
       "fishingGearRegulation": {
         "name": "Fishing gear regulation",

--- a/src/state/__tests__/state-machine/expansion/atmospheric-deposition.spec.ts
+++ b/src/state/__tests__/state-machine/expansion/atmospheric-deposition.spec.ts
@@ -1,32 +1,32 @@
-import { expect, test } from "vitest";
-import { getTestActor } from "../../utils";
-import { filter, find } from "lodash";
+import { expect } from "vitest";
+import { getTestActor, testRandomSeed } from "../../utils";
+import { find, without } from "lodash";
 
-test("removing calanoida from animal table", async () => {
+testRandomSeed("removing calanoida from animal table", async (seed) => {
   const { getState, activatePolicy } = getTestActor({
     useSpecialCards: true,
+    seed,
   });
   const stateBefore = getState();
   stateBefore.animalMarket.deck = [...stateBefore.animalMarket.deck, ...stateBefore.animalMarket.table];
   stateBefore.animalMarket.table = [];
   const calanoida = find(stateBefore.animalMarket.deck, { name: "Calanoida" })!;
-  stateBefore.animalMarket.table = filter(
-    stateBefore.animalMarket.deck,
-    (animalDeckCard) => animalDeckCard.name !== "Calanoida",
-  ).slice(0, 3);
+  stateBefore.animalMarket.deck = without(stateBefore.animalMarket.deck, calanoida);
+  stateBefore.animalMarket.table = stateBefore.animalMarket.deck.slice(0, 3);
   stateBefore.animalMarket.table.push(calanoida);
 
   activatePolicy({
     policyName: "Atmospheric deposition of hazardous substances",
     stateBefore,
+    specialCardSource: "plants",
   });
 
   const state = getState();
-  expect(state.animalMarket.table).not.toContain(calanoida);
+  expect(state.animalMarket.table.includes(calanoida)).toBe(false);
   expect(state.animalMarket.table).toHaveLength(4);
 });
 
-test("removing calanoida from animal deck", async () => {
+testRandomSeed("removing calanoida from animal deck", async () => {
   const { activatePolicy, getState } = getTestActor({
     useSpecialCards: true,
   });
@@ -45,9 +45,10 @@ test("removing calanoida from animal deck", async () => {
   expect(state.animalMarket.deck.includes(calanoida)).toBe(false);
 });
 
-test("removing calanoida from player hand", async () => {
+testRandomSeed("removing calanoida from player hand", async (seed) => {
   const { activatePolicy, getState } = getTestActor({
     useSpecialCards: true,
+    seed,
   });
   const stateBefore = getState();
   stateBefore.animalMarket.deck = [...stateBefore.animalMarket.deck, ...stateBefore.animalMarket.table];
@@ -65,9 +66,10 @@ test("removing calanoida from player hand", async () => {
   expect(state.players[0].hand.includes(calanoida)).toBe(false);
 });
 
-test("removing calanoida from player deck", async () => {
+testRandomSeed("removing calanoida from player deck", async (seed) => {
   const { activatePolicy, getState } = getTestActor({
     useSpecialCards: true,
+    seed,
   });
   const stateBefore = getState();
   stateBefore.animalMarket.deck = [...stateBefore.animalMarket.deck, ...stateBefore.animalMarket.table];
@@ -85,9 +87,10 @@ test("removing calanoida from player deck", async () => {
   expect(state.players[0].deck.includes(calanoida)).toBe(false);
 });
 
-test("removing calanoida from player discard", async () => {
+testRandomSeed("removing calanoida from player discard", async (seed) => {
   const { activatePolicy, getState } = getTestActor({
     useSpecialCards: true,
+    seed,
   });
   const stateBefore = getState();
   stateBefore.animalMarket.deck = [...stateBefore.animalMarket.deck, ...stateBefore.animalMarket.table];
@@ -105,10 +108,11 @@ test("removing calanoida from player discard", async () => {
   expect(state.players[0].discard.includes(calanoida)).toBe(false);
 });
 
-test("removing calanoida from multiplayer cards", async () => {
+testRandomSeed("removing calanoida from multiplayer cards", async (seed) => {
   const { activatePolicy, getState } = getTestActor({
     useSpecialCards: true,
     playerCount: 4,
+    seed,
   });
   const stateBefore = getState();
   stateBefore.animalMarket.deck = [...stateBefore.animalMarket.deck, ...stateBefore.animalMarket.table];
@@ -126,10 +130,11 @@ test("removing calanoida from multiplayer cards", async () => {
   expect(state.players[2].hand.includes(calanoida)).toBe(false);
 });
 
-test("removing calanoida from multiplayer hand", async () => {
+testRandomSeed("removing calanoida from multiplayer hand", async (seed) => {
   const { activatePolicy, getState } = getTestActor({
     useSpecialCards: true,
     playerCount: 4,
+    seed,
   });
   const stateBefore = getState();
   stateBefore.animalMarket.deck = [...stateBefore.animalMarket.deck, ...stateBefore.animalMarket.table];
@@ -147,10 +152,11 @@ test("removing calanoida from multiplayer hand", async () => {
   expect(state.players[2].hand.includes(calanoida)).toBe(false);
 });
 
-test("removing calanoida from multiplayer deck", async () => {
+testRandomSeed("removing calanoida from multiplayer deck", async (seed) => {
   const { activatePolicy, getState } = getTestActor({
     useSpecialCards: true,
     playerCount: 4,
+    seed,
   });
   const stateBefore = getState();
   stateBefore.animalMarket.deck = [...stateBefore.animalMarket.deck, ...stateBefore.animalMarket.table];
@@ -168,10 +174,11 @@ test("removing calanoida from multiplayer deck", async () => {
   expect(state.players[2].deck.includes(calanoida)).toBe(false);
 });
 
-test("removing calanoida from multiplayer discard", async () => {
+testRandomSeed("removing calanoida from multiplayer discard", async (seed) => {
   const { activatePolicy, getState } = getTestActor({
     useSpecialCards: true,
     playerCount: 4,
+    seed,
   });
   const stateBefore = getState();
   stateBefore.animalMarket.deck = [...stateBefore.animalMarket.deck, ...stateBefore.animalMarket.table];

--- a/src/state/__tests__/state-machine/expansion/bubble-curtains.spec.ts
+++ b/src/state/__tests__/state-machine/expansion/bubble-curtains.spec.ts
@@ -1,9 +1,10 @@
-import { test, expect } from "vitest";
-import { getTestActor } from "@/state/__tests__/utils";
+import { expect } from "vitest";
+import { getTestActor, testRandomSeed } from "@/state/__tests__/utils";
 
-test("restores single ability in singleplayer", async () => {
+testRandomSeed("restores single ability in singleplayer", async (seed) => {
   const { activatePolicy, getState } = getTestActor({
     useSpecialCards: true,
+    seed,
   });
   const stateBefore = getState();
 
@@ -12,30 +13,34 @@ test("restores single ability in singleplayer", async () => {
   activatePolicy({
     policyName: "Bubble curtains",
     stateBefore,
+    specialCardSource: "plants",
   });
 
   const state = getState();
   expect(state.players[0].abilities.every((ability) => !ability.isUsed)).toBe(true);
 });
 
-test("restores abilities after using special abilities", async () => {
+testRandomSeed("restores abilities after using special abilities", async (seed) => {
   const { activatePolicy, getState } = getTestActor({
     useSpecialCards: true,
+    seed,
   });
   const stateBefore = getState();
 
   activatePolicy({
     policyName: "Bubble curtains",
     stateBefore,
+    specialCardSource: "plants",
   });
 
   const state = getState();
   expect(state.players[0].abilities.every((ability) => !ability.isUsed)).toBe(true);
 });
 
-test("restores all abilities in singleplayer", async () => {
+testRandomSeed("restores all abilities in singleplayer", async (seed) => {
   const { activatePolicy, getState } = getTestActor({
     useSpecialCards: true,
+    seed,
   });
   const stateBefore = getState();
 
@@ -47,16 +52,18 @@ test("restores all abilities in singleplayer", async () => {
   activatePolicy({
     policyName: "Bubble curtains",
     stateBefore,
+    specialCardSource: "plants",
   });
 
   const state = getState();
   expect(state.players[0].abilities.every((ability) => !ability.isUsed)).toBe(true);
 });
 
-test("restores abilities in multiplayer", async () => {
+testRandomSeed("restores abilities in multiplayer", async (seed) => {
   const { activatePolicy, getState } = getTestActor({
     useSpecialCards: true,
     playerCount: 4,
+    seed,
   });
   const stateBefore = getState();
 
@@ -68,6 +75,7 @@ test("restores abilities in multiplayer", async () => {
   activatePolicy({
     policyName: "Bubble curtains",
     stateBefore,
+    specialCardSource: "plants",
   });
 
   const state = getState();

--- a/src/state/__tests__/state-machine/expansion/excessive-fertilizer-use.spec.ts
+++ b/src/state/__tests__/state-machine/expansion/excessive-fertilizer-use.spec.ts
@@ -1,9 +1,10 @@
-import { test, expect } from "vitest";
-import { getTestActor } from "@/state/__tests__/utils";
+import { expect } from "vitest";
+import { getTestActor, testRandomSeed } from "@/state/__tests__/utils";
 
-test("distributing nutrient cards to active player", async () => {
+testRandomSeed("distributing nutrient cards to active player", async (seed) => {
   const { activatePolicy, getState } = getTestActor({
     useSpecialCards: true,
+    seed,
   });
   const stateBefore = getState();
 
@@ -26,9 +27,10 @@ test("distributing nutrient cards to active player", async () => {
   expect(playerNutrientsAfter - playerNutrientsBefore).toBe(2);
 });
 
-test("distributing disaster card to active player", async () => {
+testRandomSeed("distributing disaster card to active player", async (seed) => {
   const { activatePolicy, getState } = getTestActor({
     useSpecialCards: true,
+    seed,
   });
   const stateBefore = getState();
 
@@ -54,10 +56,11 @@ test("distributing disaster card to active player", async () => {
   expect(state.players[0].hand.filter((card) => card.type === "disaster").length).toBe(1);
 });
 
-test("removing oxygen cards from hands", async () => {
+testRandomSeed("removing oxygen cards from hands", async (seed) => {
   const { activatePolicy, getState } = getTestActor({
     useSpecialCards: true,
     playerCount: 4,
+    seed,
   });
   const stateBefore = getState();
 

--- a/src/state/__tests__/state-machine/expansion/fishing-gear-regulation.spec.ts
+++ b/src/state/__tests__/state-machine/expansion/fishing-gear-regulation.spec.ts
@@ -1,0 +1,115 @@
+import { expect } from "vitest";
+import { getTestActor, testRandomSeed } from "@/state/__tests__/utils";
+import { concat, every, filter, find, some, without } from "lodash";
+
+testRandomSeed("moving mud species to self", async (seed) => {
+  const { send, getState, activatePolicy } = getTestActor({ useSpecialCards: true, playerCount: 2, seed });
+  const stateBefore = getState();
+
+  const mudAnimals = filter([...stateBefore.animalMarket.table, ...stateBefore.animalMarket.deck], (card) =>
+    card.habitats.includes("mud"),
+  ).slice(0, 4);
+  stateBefore.animalMarket.table = mudAnimals;
+  stateBefore.animalMarket.deck = without(stateBefore.animalMarket.deck, ...mudAnimals);
+
+  const mudPlants = filter([...stateBefore.plantMarket.table, ...stateBefore.plantMarket.deck], (card) =>
+    card.habitats.includes("mud"),
+  ).slice(0, 4);
+  stateBefore.plantMarket.table = mudPlants;
+  stateBefore.plantMarket.deck = without(stateBefore.plantMarket.deck, ...mudPlants);
+
+  activatePolicy({
+    policyName: "Fishing gear regulation",
+    stateBefore,
+  });
+
+  send({ type: "user.click.player.hand.card", card: stateBefore.players[0].hand[0] });
+
+  const state = getState();
+  expect(every(stateBefore.animalMarket.table, (animalCard) => state.animalMarket.table.includes(animalCard))).toBe(
+    false,
+  );
+  expect(state.animalMarket.table).toHaveLength(4);
+  expect(every(stateBefore.plantMarket.table, (plantCard) => state.plantMarket.table.includes(plantCard))).toBe(false);
+  expect(state.plantMarket.table).toHaveLength(4);
+  expect(every(stateBefore.animalMarket.table, (animalCard) => state.players[0].hand.includes(animalCard))).toBe(true);
+  expect(every(stateBefore.plantMarket.table, (plantCard) => state.players[0].hand.includes(plantCard))).toBe(true);
+});
+
+testRandomSeed("moving mud species to other player", async (seed) => {
+  const { send, getState, activatePolicy } = getTestActor({ useSpecialCards: true, playerCount: 2, seed });
+  const stateBefore = getState();
+
+  const mudAnimals = filter([...stateBefore.animalMarket.table, ...stateBefore.animalMarket.deck], (card) =>
+    card.habitats.includes("mud"),
+  ).slice(0, 4);
+  stateBefore.animalMarket.table = mudAnimals;
+  stateBefore.animalMarket.deck = without(stateBefore.animalMarket.deck, ...mudAnimals);
+
+  const mudPlants = filter([...stateBefore.plantMarket.table, ...stateBefore.plantMarket.deck], (card) =>
+    card.habitats.includes("mud"),
+  ).slice(0, 4);
+  stateBefore.plantMarket.table = mudPlants;
+  stateBefore.plantMarket.deck = without(stateBefore.plantMarket.deck, ...mudPlants);
+
+  activatePolicy({
+    policyName: "Fishing gear regulation",
+    stateBefore,
+  });
+  send({ type: "user.click.player.hand.card", card: stateBefore.players[1].hand[0] });
+
+  const state = getState();
+  expect(every(stateBefore.animalMarket.table, (animalCard) => state.animalMarket.table.includes(animalCard))).toBe(
+    false,
+  );
+  expect(state.animalMarket.table).toHaveLength(4);
+  expect(every(stateBefore.plantMarket.table, (plantCard) => state.plantMarket.table.includes(plantCard))).toBe(false);
+  expect(state.plantMarket.table).toHaveLength(4);
+  expect(every(stateBefore.animalMarket.table, (animalCard) => state.players[1].hand.includes(animalCard))).toBe(true);
+  expect(every(stateBefore.plantMarket.table, (plantCard) => state.players[1].hand.includes(plantCard))).toBe(true);
+});
+
+testRandomSeed("no mud species in market", async (seed) => {
+  const { send, getState, activatePolicy } = getTestActor({ useSpecialCards: true, playerCount: 2, seed });
+  const stateBefore = getState();
+
+  stateBefore.animalMarket.table = filter(
+    [...stateBefore.animalMarket.table, ...stateBefore.animalMarket.deck],
+    (card) => !card.habitats.includes("mud"),
+  ).slice(0, 4);
+  stateBefore.plantMarket.table = filter(
+    [...stateBefore.plantMarket.table, ...stateBefore.plantMarket.deck],
+    (card) => !card.habitats.includes("mud"),
+  ).slice(0, 4);
+
+  const specialCards = filter(stateBefore.animalMarket.deck, (animalDeckCard) =>
+    animalDeckCard.abilities.includes("special"),
+  ).slice(0, 2);
+  stateBefore.players[0].hand = concat(stateBefore.players[0].hand, specialCards);
+  const fundingCard = find(stateBefore.policyMarket.deck, { name: "Funding" })!;
+  const fishingGearRegulationCard = find(stateBefore.policyMarket.deck, {
+    name: "Fishing gear regulation",
+  })!;
+  stateBefore.policyMarket.deck = [fundingCard, fishingGearRegulationCard];
+
+  send({
+    type: "iddqd",
+    context: stateBefore,
+  });
+
+  activatePolicy({
+    policyName: "Fishing gear regulation",
+    stateBefore,
+  });
+  send({ type: "user.click.player.hand.card", card: stateBefore.players[1].hand[0] });
+
+  const state = getState();
+  expect(every(stateBefore.animalMarket.table, (animalCard) => state.animalMarket.table.includes(animalCard))).toBe(
+    true,
+  );
+  expect(state.animalMarket.table).toHaveLength(4);
+  expect(every(stateBefore.plantMarket.table, (plantCard) => state.plantMarket.table.includes(plantCard))).toBe(true);
+  expect(state.plantMarket.table).toHaveLength(4);
+  expect(some(stateBefore.animalMarket.table, (animalCard) => state.players[1].hand.includes(animalCard))).toBe(false);
+  expect(some(stateBefore.plantMarket.table, (plantCard) => state.players[1].hand.includes(plantCard))).toBe(false);
+});

--- a/src/state/__tests__/state-machine/expansion/green-energy.spec.ts
+++ b/src/state/__tests__/state-machine/expansion/green-energy.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "vitest";
+import { getTestActor, testRandomSeed } from "@/state/__tests__/utils";
+import { find } from "lodash";
+import { HabitatName } from "@/state/types";
+
+test.each<{ habitatName: HabitatName }>([{ habitatName: "mud" }, { habitatName: "rock" }, { habitatName: "coast" }])(
+  "%s habitat acquired causes extinction",
+  async ({ habitatName }) => {
+    const { getState, activatePolicy } = getTestActor({ useSpecialCards: true, playerCount: 1 });
+    const stateBefore = getState();
+
+    const mudHabitat = stateBefore.habitatMarket.deck.find((habitatTile) => habitatTile.name === habitatName)!;
+    mudHabitat.isAcquired = true;
+
+    activatePolicy({
+      policyName: "Green energy",
+      stateBefore,
+    });
+
+    const state = getState();
+    expect(state.commandBar).toBeUndefined();
+    expect(stateBefore.extinctMarket.table.length - state.extinctMarket.table.length).toBe(-1);
+  },
+);
+
+test.each<{ habitatName: HabitatName }>([{ habitatName: "mud" }, { habitatName: "rock" }, { habitatName: "coast" }])(
+  "mud and rock and coast habitat not acquired unlocks %s",
+  async ({ habitatName }) => {
+    const { send, getState, activatePolicy } = getTestActor({ useSpecialCards: true, playerCount: 1 });
+    const stateBefore = getState();
+
+    activatePolicy({
+      policyName: "Green energy",
+      stateBefore,
+    });
+    send({ type: "user.click.market.deck.habitat", name: habitatName });
+
+    const state = getState();
+    expect(state.commandBar).toBeUndefined();
+    expect(find(state.habitatMarket.deck, { name: habitatName })?.isAcquired).toBe(true);
+  },
+);
+
+testRandomSeed("allow only mud and rock and coast habitats to be unlocked", async (seed) => {
+  const { send, getState, activatePolicy } = getTestActor({ useSpecialCards: true, playerCount: 1, seed });
+  const stateBefore = getState();
+
+  activatePolicy({
+    policyName: "Green energy",
+    stateBefore,
+  });
+  send({ type: "user.click.market.deck.habitat", name: "rivers" });
+
+  const state = getState();
+  expect(state.commandBar).toBeDefined();
+  expect(find(state.habitatMarket.deck, { name: "rivers" })?.isAcquired).toBe(false);
+});

--- a/src/state/__tests__/state-machine/expansion/habitat-restoration.spec.ts
+++ b/src/state/__tests__/state-machine/expansion/habitat-restoration.spec.ts
@@ -1,10 +1,11 @@
-import { test, expect } from "vitest";
-import { getTestActor } from "@/state/__tests__/utils";
+import { expect } from "vitest";
+import { getTestActor, testRandomSeed } from "@/state/__tests__/utils";
 import { without } from "lodash";
 
-test("restoring extinction tile", async () => {
+testRandomSeed("restoring extinction tile", async (seed) => {
   const { activatePolicy, getState } = getTestActor({
     useSpecialCards: true,
+    seed,
   });
   const stateBefore = getState();
 

--- a/src/state/__tests__/state-machine/expansion/hazardous-industrial-substances.spec.ts
+++ b/src/state/__tests__/state-machine/expansion/hazardous-industrial-substances.spec.ts
@@ -1,9 +1,10 @@
-import { test, expect } from "vitest";
-import { getTestActor } from "@/state/__tests__/utils";
+import { expect } from "vitest";
+import { getTestActor, testRandomSeed } from "@/state/__tests__/utils";
 
-test("discarding plant market", async () => {
+testRandomSeed("discarding plant market", async (seed) => {
   const { activatePolicy, getState } = getTestActor({
     useSpecialCards: true,
+    seed,
   });
   const stateBefore = getState();
   const tablePlantsBefore = stateBefore.plantMarket.table;
@@ -27,9 +28,10 @@ test("discarding plant market", async () => {
   expect(state.plantMarket.table).toHaveLength(4);
 });
 
-test("discarding plant market when deck is empty", async () => {
+testRandomSeed("discarding plant market when deck is empty", async (seed) => {
   const { activatePolicy, getState } = getTestActor({
     useSpecialCards: true,
+    seed,
   });
   const stateBefore = getState();
   const tablePlantsBefore = stateBefore.plantMarket.table;
@@ -55,9 +57,10 @@ test("discarding plant market when deck is empty", async () => {
   expect(state.plantMarket.table).toHaveLength(0);
 });
 
-test("discarding plant market when deck is partially empty", async () => {
+testRandomSeed("discarding plant market when deck is partially empty", async (seed) => {
   const { activatePolicy, getState } = getTestActor({
     useSpecialCards: true,
+    seed,
   });
   const stateBefore = getState();
   const tablePlantsBefore = stateBefore.plantMarket.table;
@@ -83,13 +86,16 @@ test("discarding plant market when deck is partially empty", async () => {
   expect(state.plantMarket.table).toHaveLength(2);
 });
 
-test("discarding singleplayer with plants", async () => {
+testRandomSeed("discarding singleplayer with plants", async (seed) => {
   const { activatePolicy, getState } = getTestActor({
     useSpecialCards: true,
     playerCount: 1,
+    seed,
   });
   const stateBefore = getState();
-  const plantCards = stateBefore.plantMarket.table.filter((card) => card.type === "plant");
+  const plantCards = stateBefore.plantMarket.table.filter(
+    (card) => card.type === "plant" && !card.abilities.includes("special"),
+  );
   stateBefore.players[0].hand = [...stateBefore.players[0].hand, ...plantCards];
 
   activatePolicy({
@@ -107,13 +113,14 @@ test("discarding singleplayer with plants", async () => {
   expect(state.players[0].hand).toHaveLength(5);
 });
 
-test("discarding multiplayer with plants", async () => {
+testRandomSeed("discarding multiplayer with plants", async (seed) => {
   const { activatePolicy, getState } = getTestActor({
     useSpecialCards: true,
     playerCount: 4,
+    seed,
   });
   const stateBefore = getState();
-  const plantCards = stateBefore.plantMarket.table.slice(0, 4);
+  const plantCards = stateBefore.plantMarket.deck.filter((card) => !card.abilities.includes("special")).slice(0, 4);
   stateBefore.players.forEach((player, index) => {
     player.hand.push(plantCards[index]);
   });
@@ -136,10 +143,11 @@ test("discarding multiplayer with plants", async () => {
   expect(state.players.slice(1, 4).every((player) => player.hand.length === 4)).toBe(true);
 });
 
-test("discarding singleplayer without plants", async () => {
+testRandomSeed("discarding singleplayer without plants", async (seed) => {
   const { activatePolicy, getState } = getTestActor({
     useSpecialCards: true,
     playerCount: 1,
+    seed,
   });
   const stateBefore = getState();
 
@@ -152,10 +160,11 @@ test("discarding singleplayer without plants", async () => {
   expect(state.players[0].hand).toHaveLength(5);
 });
 
-test("discarding multiplayer without plants", async () => {
+testRandomSeed("discarding multiplayer without plants", async (seed) => {
   const { activatePolicy, getState } = getTestActor({
     useSpecialCards: true,
     playerCount: 4,
+    seed,
   });
   const stateBefore = getState();
 

--- a/src/state/__tests__/state-machine/expansion/hunting.spec.ts
+++ b/src/state/__tests__/state-machine/expansion/hunting.spec.ts
@@ -1,10 +1,11 @@
-import { expect, test } from "vitest";
-import { getTestActor } from "@/state/__tests__/utils";
+import { expect } from "vitest";
+import { getTestActor, testRandomSeed } from "@/state/__tests__/utils";
 import { remove } from "lodash";
 
-test("removing birds from hand", async () => {
+testRandomSeed("removing birds from hand", async (seed) => {
   const { activatePolicy, getState } = getTestActor({
     useSpecialCards: true,
+    seed,
   });
   const stateBefore = getState();
   const birds = remove(stateBefore.animalMarket.deck, { faunaType: "bird" });
@@ -18,12 +19,13 @@ test("removing birds from hand", async () => {
 
   const state = getState();
   expect(birds.some((bird) => state.players[0].hand.includes(bird))).toBe(false);
-  expect(state.players[0].hand).toEqual(handBeforeAddingBirds);
+  expect(handBeforeAddingBirds.every((card) => state.players[0].hand.includes(card))).toBe(true);
 });
 
-test("removing mammals from hand", async () => {
+testRandomSeed("removing mammals from hand", async (seed) => {
   const { activatePolicy, getState } = getTestActor({
     useSpecialCards: true,
+    seed,
   });
   const stateBefore = getState();
   const specialCards = remove(stateBefore.plantMarket.deck, { abilities: ["special"] });
@@ -39,13 +41,14 @@ test("removing mammals from hand", async () => {
   });
 
   const state = getState();
-  expect(state.players[0].hand).toEqual(handBeforeAddingMammals);
+  expect(handBeforeAddingMammals.every((card) => state.players[0].hand.includes(card))).toBe(true);
   expect(mammals.some((mammal) => state.players[0].hand.includes(mammal))).toBe(false);
 });
 
-test("removing birds and mammals from hand", async () => {
+testRandomSeed("removing birds and mammals from hand", async (seed) => {
   const { activatePolicy, getState } = getTestActor({
     useSpecialCards: true,
+    seed,
   });
   const stateBefore = getState();
   const birds = remove(stateBefore.animalMarket.deck, { faunaType: "bird" });
@@ -56,33 +59,37 @@ test("removing birds and mammals from hand", async () => {
   activatePolicy({
     policyName: "Hunting",
     stateBefore,
+    specialCardSource: "plants",
   });
 
   const state = getState();
   expect(birds.some((bird) => state.players[0].hand.includes(bird))).toBe(false);
   expect(mammals.some((mammal) => state.players[0].hand.includes(mammal))).toBe(false);
-  expect(state.players[0].hand).toEqual(handBeforeAddingAnimals);
+  expect(handBeforeAddingAnimals.every((card) => state.players[0].hand.includes(card))).toBe(true);
 });
 
-test("removing when hand contains no birds or mammals", async () => {
+testRandomSeed("removing when hand contains no birds or mammals", async (seed) => {
   const { activatePolicy, getState } = getTestActor({
     useSpecialCards: true,
+    seed,
   });
   const stateBefore = getState();
-  const handBefore = [...stateBefore.players[0].hand];
 
   activatePolicy({
     policyName: "Hunting",
     stateBefore,
+    specialCardSource: "plants",
   });
 
   const state = getState();
-  expect(state.players[0].hand).toEqual(handBefore);
+  expect(state.players[0].hand).toHaveLength(5);
+  expect(state.players[0].hand.filter((card) => card.type === "animal")).toHaveLength(0);
 });
 
-test("other animals remain in hand after hunting", async () => {
+testRandomSeed("other animals remain in hand after hunting", async (seed) => {
   const { activatePolicy, getState } = getTestActor({
     useSpecialCards: true,
+    seed,
   });
   const stateBefore = getState();
 

--- a/src/state/__tests__/state-machine/expansion/improved-nutrient-retention.spec.ts
+++ b/src/state/__tests__/state-machine/expansion/improved-nutrient-retention.spec.ts
@@ -1,5 +1,5 @@
-import { test, expect } from "vitest";
-import { getTestActor } from "@/state/__tests__/utils";
+import { expect } from "vitest";
+import { getTestActor, testRandomSeed } from "@/state/__tests__/utils";
 import { GameState, PlantCard } from "@/state/types";
 
 const getAllPlantCards = (state: GameState): PlantCard[] => {
@@ -14,11 +14,12 @@ const getAllPlantCards = (state: GameState): PlantCard[] => {
   ];
 };
 
-test("all plant cards require one less nutrient", async () => {
-  const { activatePolicy, getState, send } = getTestActor({
+testRandomSeed("all plant cards require one less nutrient", async (seed) => {
+  const { activatePolicy, getState } = getTestActor({
     useSpecialCards: true,
     playerCount: 4,
     difficulty: 1,
+    seed,
   });
   const stateBefore = getState();
   const plantCardsBefore = getAllPlantCards(stateBefore);
@@ -27,8 +28,6 @@ test("all plant cards require one less nutrient", async () => {
     policyName: "Improved nutrient retention in agriculture",
     stateBefore,
   });
-
-  send({ type: "user.click.stage.confirm" });
 
   const state = getState();
   const plantCardsAfter = getAllPlantCards(state);

--- a/src/state/__tests__/state-machine/expansion/migratory-barrier-removal.spec.ts
+++ b/src/state/__tests__/state-machine/expansion/migratory-barrier-removal.spec.ts
@@ -1,0 +1,104 @@
+import { expect } from "vitest";
+import { getTestActor, testRandomSeed } from "@/state/__tests__/utils";
+import { without } from "lodash";
+
+testRandomSeed("moving bird to self", async (seed) => {
+  const { send, getState, activatePolicy } = getTestActor({ useSpecialCards: true, playerCount: 1, seed });
+  const stateBefore = getState();
+
+  const deckBirds = stateBefore.animalMarket.deck.filter((card) => card.faunaType === "bird").slice(0, 4);
+  stateBefore.animalMarket.deck = without(stateBefore.animalMarket.deck, ...deckBirds);
+  stateBefore.animalMarket.table = deckBirds;
+  const targetBird = stateBefore.animalMarket.table[0];
+
+  activatePolicy({
+    policyName: "Migratory barrier removal",
+    stateBefore,
+    specialCardSource: "plants",
+  });
+  send({ type: "user.click.market.table.card", card: targetBird });
+  send({ type: "user.click.player.hand.card", card: stateBefore.players[0].hand[0] });
+
+  const state = getState();
+  expect(state.animalMarket.table.includes(targetBird)).toBe(false);
+  expect(state.animalMarket.table).toHaveLength(4);
+  expect(stateBefore.animalMarket.deck.length - state.animalMarket.deck.length).toBe(1);
+  expect(state.players[0].hand.includes(targetBird)).toBe(true);
+  expect(state.players[0].hand).toHaveLength(7);
+});
+
+testRandomSeed("moving bird to other player", async (seed) => {
+  const { send, getState, activatePolicy } = getTestActor({ useSpecialCards: true, playerCount: 2, seed });
+  const stateBefore = getState();
+
+  const deckBirds = stateBefore.animalMarket.deck.filter((card) => card.faunaType === "bird").slice(0, 4);
+  stateBefore.animalMarket.deck = without(stateBefore.animalMarket.deck, ...deckBirds);
+  stateBefore.animalMarket.table = deckBirds;
+  const targetBird = stateBefore.animalMarket.table[0];
+
+  activatePolicy({
+    policyName: "Migratory barrier removal",
+    stateBefore,
+    specialCardSource: "plants",
+  });
+  send({ type: "user.click.market.table.card", card: targetBird });
+  send({ type: "user.click.player.hand.card", card: stateBefore.players[1].hand[0] });
+
+  const state = getState();
+  expect(state.animalMarket.table.includes(targetBird)).toBe(false);
+  expect(state.animalMarket.table).toHaveLength(4);
+  expect(stateBefore.animalMarket.deck.length - state.animalMarket.deck.length).toBe(1);
+  expect(state.players[1].hand.includes(targetBird)).toBe(true);
+  expect(state.players[1].hand).toHaveLength(5);
+});
+
+testRandomSeed("moving fish to self", async (seed) => {
+  const { send, getState, activatePolicy } = getTestActor({ useSpecialCards: true, playerCount: 2, seed });
+  const stateBefore = getState();
+
+  const deckFish = stateBefore.animalMarket.deck.filter((card) => card.faunaType === "fish").slice(0, 4);
+  stateBefore.animalMarket.deck = without(stateBefore.animalMarket.deck, ...deckFish);
+  stateBefore.animalMarket.table = deckFish;
+  const targetFish = stateBefore.animalMarket.table[0];
+
+  activatePolicy({
+    policyName: "Migratory barrier removal",
+    stateBefore,
+    specialCardSource: "plants",
+  });
+  send({ type: "user.click.market.table.card", card: targetFish });
+  send({ type: "user.click.player.hand.card", card: stateBefore.players[0].hand[0] });
+
+  const state = getState();
+  expect(state.animalMarket.table.includes(targetFish)).toBe(false);
+  expect(state.animalMarket.table).toHaveLength(4);
+  expect(stateBefore.animalMarket.deck.length - state.animalMarket.deck.length).toBe(1);
+  expect(state.players[0].hand.includes(targetFish)).toBe(true);
+  expect(state.players[0].hand).toHaveLength(7);
+});
+
+testRandomSeed("moving fish to other player", async (seed) => {
+  const { send, getState, activatePolicy } = getTestActor({ useSpecialCards: true, playerCount: 2, seed });
+  const stateBefore = getState();
+
+  const deckFish = stateBefore.animalMarket.deck.filter((card) => card.faunaType === "fish").slice(0, 4);
+  stateBefore.animalMarket.deck = without(stateBefore.animalMarket.deck, ...deckFish);
+  stateBefore.animalMarket.table = deckFish;
+  const targetFish = stateBefore.animalMarket.table[0];
+
+  activatePolicy({
+    policyName: "Migratory barrier removal",
+    stateBefore,
+    specialCardSource: "plants",
+  });
+  send({ type: "user.click.market.table.card", card: targetFish });
+  send({ type: "user.click.player.hand.card", card: stateBefore.players[1].hand[0] });
+
+  const state = getState();
+  expect(state.commandBar).toBeUndefined();
+  expect(state.animalMarket.table.includes(targetFish)).toBe(false);
+  expect(state.animalMarket.table).toHaveLength(4);
+  expect(stateBefore.animalMarket.deck.length - state.animalMarket.deck.length).toBe(1);
+  expect(state.players[1].hand.includes(targetFish)).toBe(true);
+  expect(state.players[1].hand).toHaveLength(5);
+});

--- a/src/state/__tests__/state-machine/expansion/nutrient-upwelling.spec.ts
+++ b/src/state/__tests__/state-machine/expansion/nutrient-upwelling.spec.ts
@@ -1,11 +1,12 @@
-import { test, expect } from "vitest";
-import { getTestActor } from "@/state/__tests__/utils";
+import { expect } from "vitest";
+import { getTestActor, testRandomSeed } from "@/state/__tests__/utils";
 import { filter } from "lodash";
 
-test("distributes two elements in singplayer", async () => {
+testRandomSeed("distributes two elements in singplayer", async (seed) => {
   const { activatePolicy, getState, send } = getTestActor({
     useSpecialCards: true,
     playerCount: 1,
+    seed,
   });
   const stateBefore = getState();
 
@@ -29,10 +30,11 @@ test("distributes two elements in singplayer", async () => {
   expect(filter(state.players[0].hand, { name: "nutrients" })).toHaveLength(2);
 });
 
-test("partially distributes elements in singplayer", async () => {
+testRandomSeed("partially distributes elements in singplayer", async (seed) => {
   const { activatePolicy, getState, send } = getTestActor({
     useSpecialCards: true,
     playerCount: 1,
+    seed,
   });
   const stateBefore = getState();
 
@@ -61,11 +63,12 @@ test("partially distributes elements in singplayer", async () => {
   expect(filter(state.elementMarket.deck, { name: "nutrients" })).toHaveLength(0);
 });
 
-test("distributes two elements in multiplayer", async () => {
+testRandomSeed("distributes two elements in multiplayer", async (seed) => {
   const { activatePolicy, getState, send } = getTestActor({
     useSpecialCards: true,
     playerCount: 4,
     difficulty: 1,
+    seed,
   });
   const stateBefore = getState();
 
@@ -91,10 +94,11 @@ test("distributes two elements in multiplayer", async () => {
   expect(state.players.every((player) => filter(player.hand, { name: "nutrients" }).length === 2)).toBe(true);
 });
 
-test("partially distributes elements in multiplayer", async () => {
+testRandomSeed("partially distributes elements in multiplayer", async (seed) => {
   const { activatePolicy, getState, send } = getTestActor({
     useSpecialCards: true,
     playerCount: 4,
+    seed,
   });
   const stateBefore = getState();
 
@@ -124,10 +128,11 @@ test("partially distributes elements in multiplayer", async () => {
   expect(state.players.every((player) => filter(player.hand, { name: "nutrients" }).length === 1)).toBe(true);
 });
 
-test("no distribution with empty deck", async () => {
+testRandomSeed("no distribution with empty deck", async (seed) => {
   const { activatePolicy, getState, send } = getTestActor({
     useSpecialCards: true,
     playerCount: 4,
+    seed,
   });
   const stateBefore = getState();
 

--- a/src/state/__tests__/state-machine/expansion/recycling-and-waste-disposal.spec.ts
+++ b/src/state/__tests__/state-machine/expansion/recycling-and-waste-disposal.spec.ts
@@ -1,0 +1,185 @@
+import { expect } from "vitest";
+import { getTestActor, testRandomSeed } from "@/state/__tests__/utils";
+import { filter, first, without } from "lodash";
+
+testRandomSeed("no disaster cards in hand", async (seed) => {
+  const { getState, activatePolicy } = getTestActor({ useSpecialCards: true, playerCount: 1, seed });
+  const stateBefore = getState();
+
+  stateBefore.players[0].deck = [...stateBefore.players[0].hand, ...stateBefore.players[0].deck].filter(
+    (card) => card.type !== "disaster",
+  );
+  const playerHandBefore = (stateBefore.players[0].hand = stateBefore.players[0].deck.slice(0, 4));
+  stateBefore.players[0].deck = without(stateBefore.players[0].deck, ...playerHandBefore);
+
+  activatePolicy({
+    policyName: "Recycling and waste disposal",
+    stateBefore,
+  });
+
+  const state = getState();
+  expect(state.commandBar).toBeUndefined();
+  expect(playerHandBefore.every((card) => state.players[0].hand.includes(card))).toBe(true);
+  expect(state.players[0].hand).toHaveLength(6);
+});
+
+testRandomSeed("cant select non disaster card", async (seed) => {
+  const { send, getState, activatePolicy } = getTestActor({ useSpecialCards: true, playerCount: 1, seed });
+  const stateBefore = getState();
+
+  stateBefore.players[0].deck = [...stateBefore.players[0].hand, ...stateBefore.players[0].deck];
+  const playerHandBefore = (stateBefore.players[0].hand = [
+    ...stateBefore.players[0].deck.filter((card) => card.type !== "disaster").slice(0, 3),
+    ...stateBefore.players[0].deck.filter((card) => card.type === "disaster").slice(0, 1),
+  ]);
+  stateBefore.players[0].deck = without(stateBefore.players[0].deck, ...playerHandBefore);
+
+  activatePolicy({
+    policyName: "Recycling and waste disposal",
+    stateBefore,
+  });
+  send({ type: "user.click.player.hand.card", card: stateBefore.players[0].hand[0] });
+
+  const state = getState();
+  expect(state.commandBar).toBeDefined();
+  expect(playerHandBefore.every((card) => state.players[0].hand.includes(card))).toBe(true);
+  expect(state.players[0].hand).toHaveLength(6);
+});
+
+testRandomSeed("single disaster card in hand", async (seed) => {
+  const { send, getState, activatePolicy } = getTestActor({ useSpecialCards: true, playerCount: 1, seed });
+  const stateBefore = getState();
+
+  stateBefore.players[0].deck = [...stateBefore.players[0].hand, ...stateBefore.players[0].deck];
+  stateBefore.players[0].hand = [
+    ...stateBefore.players[0].deck.filter((card) => card.type !== "disaster").slice(0, 3),
+    ...stateBefore.players[0].deck.filter((card) => card.type === "disaster").slice(0, 1),
+  ];
+  stateBefore.players[0].deck = without(stateBefore.players[0].deck, ...stateBefore.players[0].hand);
+  stateBefore.players[0].deck = stateBefore.players[0].deck.filter((card) => card.type !== "disaster");
+
+  activatePolicy({
+    policyName: "Recycling and waste disposal",
+    stateBefore,
+  });
+  send({ type: "user.click.player.hand.card", card: stateBefore.players[0].hand[3] });
+
+  const state = getState();
+  expect(state.commandBar).toBeUndefined();
+  expect(state.players[0].hand.filter((card) => card.type === "disaster")).toHaveLength(0);
+  expect(state.players[0].hand).toHaveLength(6);
+});
+
+testRandomSeed("multiple disaster cards in hand", async (seed) => {
+  const { send, getState, activatePolicy } = getTestActor({ useSpecialCards: true, playerCount: 1, seed });
+  const stateBefore = getState();
+
+  stateBefore.players[0].deck = [...stateBefore.players[0].hand, ...stateBefore.players[0].deck];
+  stateBefore.players[0].hand = [
+    ...stateBefore.players[0].deck.filter((card) => card.type !== "disaster").slice(0, 2),
+    ...stateBefore.players[0].deck.filter((card) => card.type === "disaster").slice(0, 2),
+  ];
+  stateBefore.players[0].deck = without(stateBefore.players[0].deck, ...stateBefore.players[0].hand);
+  stateBefore.players[0].deck = stateBefore.players[0].deck.filter((card) => card.type !== "disaster");
+
+  activatePolicy({
+    policyName: "Recycling and waste disposal",
+    stateBefore,
+  });
+
+  send({
+    type: "user.click.player.hand.card",
+    card: first(filter(stateBefore.players[0].hand, { type: "disaster" }))!,
+  });
+
+  let state = getState();
+  expect(state.commandBar).toBeDefined();
+
+  send({
+    type: "user.click.player.hand.card",
+    card: first(filter(state.players[0].hand, { type: "disaster" }))!,
+  });
+
+  state = getState();
+  expect(state.commandBar).toBeUndefined();
+  expect(state.players[0].hand.filter((card) => card.type === "disaster")).toHaveLength(0);
+  expect(state.players[0].hand).toHaveLength(6);
+});
+
+testRandomSeed("multiple disaster cards in hand and deck is empty", async (seed) => {
+  const { send, getState, activatePolicy } = getTestActor({ useSpecialCards: true, playerCount: 1, seed });
+  const stateBefore = getState();
+
+  stateBefore.players[0].deck = [...stateBefore.players[0].hand, ...stateBefore.players[0].deck];
+  stateBefore.players[0].hand = [
+    ...stateBefore.players[0].deck.filter((card) => card.type !== "disaster").slice(0, 2),
+    ...stateBefore.players[0].deck.filter((card) => card.type === "disaster").slice(0, 2),
+  ];
+  stateBefore.players[0].deck = without(stateBefore.players[0].deck, ...stateBefore.players[0].hand);
+  stateBefore.players[0].deck = stateBefore.players[0].deck.filter((card) => card.type !== "disaster");
+  stateBefore.players[0].discard = stateBefore.players[0].deck;
+  stateBefore.players[0].deck = [];
+
+  activatePolicy({
+    policyName: "Recycling and waste disposal",
+    stateBefore,
+  });
+
+  send({
+    type: "user.click.player.hand.card",
+    card: first(filter(stateBefore.players[0].hand, { type: "disaster" }))!,
+  });
+
+  let state = getState();
+  expect(state.commandBar).toBeDefined();
+
+  send({
+    type: "user.click.player.hand.card",
+    card: first(filter(state.players[0].hand, { type: "disaster" }))!,
+  });
+
+  state = getState();
+  expect(state.commandBar).toBeUndefined();
+  expect(state.players[0].hand.filter((card) => card.type === "disaster")).toHaveLength(0);
+  expect(state.players[0].hand).toHaveLength(6);
+});
+
+testRandomSeed("multiple disaster cards in other players' hands", async (seed) => {
+  const { send, getState, activatePolicy } = getTestActor({ useSpecialCards: true, playerCount: 4, seed });
+  const stateBefore = getState();
+
+  stateBefore.players.forEach((player, index) => {
+    player.deck = [...player.hand, ...player.deck].filter((card) => card.type !== "disaster");
+    if (index === 0 || index === 1) {
+      player.hand = [...player.deck.slice(0, 3), stateBefore.disasterMarket.deck[index]];
+    } else {
+      player.hand = player.deck.slice(0, 4);
+    }
+  });
+
+  activatePolicy({
+    policyName: "Recycling and waste disposal",
+    stateBefore,
+  });
+
+  send({
+    type: "user.click.player.hand.card",
+    card: first(filter(stateBefore.players[0].hand, { type: "disaster" }))!,
+  });
+
+  let state = getState();
+  expect(state.commandBar).toBeDefined();
+
+  send({
+    type: "user.click.player.hand.card",
+    card: first(filter(state.players[1].hand, { type: "disaster" }))!,
+  });
+
+  state = getState();
+  expect(state.commandBar).toBeUndefined();
+
+  state.players.forEach((player, index) => {
+    expect(player.hand.filter((card) => card.type === "disaster")).toHaveLength(0);
+    expect(player.hand).toHaveLength(index === 0 ? 6 : 4);
+  });
+});

--- a/src/state/__tests__/state-machine/expansion/upgraded-waste-water-treatment.spec.ts
+++ b/src/state/__tests__/state-machine/expansion/upgraded-waste-water-treatment.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "vitest";
-import { getTestActor } from "@/state/__tests__/utils";
+import { getTestActor, testRandomSeed } from "@/state/__tests__/utils";
 import { filter } from "lodash";
 
 // Test skipped for now because it conflicts with the conditions for elemental disaster
@@ -31,9 +31,10 @@ test.skip("nutrient to market when player has 3 nutrients", async () => {
   expect(playerNutrientsAfter - playerNutrientsBefore).toBe(-1);
 });
 
-test("player gets additional nutrient", async () => {
+testRandomSeed("player gets additional nutrient", async (seed) => {
   const { activatePolicy, getState, send } = getTestActor({
     useSpecialCards: true,
+    seed,
   });
   const stateBefore = getState();
 
@@ -60,9 +61,10 @@ test("player gets additional nutrient", async () => {
   expect(playerNutrientsAfter - playerNutrientsBefore).toBe(1);
 });
 
-test("player gets no additional nutrient when deck is empty", async () => {
+testRandomSeed("player gets no additional nutrient when deck is empty", async (seed) => {
   const { activatePolicy, getState, send } = getTestActor({
     useSpecialCards: true,
+    seed,
   });
   const stateBefore = getState();
 

--- a/src/state/action-handlers.tsx
+++ b/src/state/action-handlers.tsx
@@ -8,6 +8,7 @@ import {
   GameState,
   AbilityName,
   PolicyCard,
+  HabitatName,
 } from "@/state/types";
 import { mapValues } from "lodash-es";
 import { EventFromLogic } from "xstate";
@@ -17,6 +18,7 @@ export interface ActionEmmiters {
   playerCardClick: (card: Card) => () => void;
   playerDeckClick: () => () => void;
   playerEndTurnClick: () => () => void;
+  habitatTileClick: (name: HabitatName) => () => void;
   marketElementClick: (name: ElementCard["name"]) => () => void;
   borrowedElementClick: (card: ElementCard) => () => void;
   marketCardClick: (card: PlantCard | AnimalCard) => () => void;
@@ -39,6 +41,7 @@ const actionToEventMap: {
   playerCardClick: (card: Card) => ({ type: "user.click.player.hand.card", card }),
   playerDeckClick: () => ({ type: "user.click.player.deck" }),
   playerEndTurnClick: () => ({ type: "user.click.player.endTurn" }),
+  habitatTileClick: (name: HabitatName) => ({ type: "user.click.market.deck.habitat", name }),
   marketElementClick: (name: ElementCard["name"]) => ({ type: "user.click.market.deck.element", name }),
   borrowedElementClick: (card: ElementCard) => ({ type: "user.click.market.borrowed.card.element", card }),
   marketCardClick: (card: PlantCard | AnimalCard) => ({ type: "user.click.market.table.card", card }),

--- a/src/state/machines/expansion/fishing_gear_regulation.ts
+++ b/src/state/machines/expansion/fishing_gear_regulation.ts
@@ -1,0 +1,122 @@
+import { Card, GameState } from "@/state/types";
+import { produce } from "immer";
+import { concat, filter, find, without } from "lodash";
+import { assign } from "@/state/machines/assign";
+import { ExpansionConditionConfig, ExpansionStateNodeConfig, ToParameterizedObject } from "@/lib/types";
+import { TurnMachineGuards } from "../guards";
+import i18n from "@/i18n";
+
+export const cardPrefix = "fishingGearRegulation";
+export const cardName = "Fishing gear regulation";
+
+export const uiStrings = {
+  [cardName]: {
+    name: i18n.t("deck.policies.fishingGearRegulation.name"),
+    description: i18n.t("deck.policies.fishingGearRegulation.description"),
+  },
+};
+
+const internalContext: { destination: Card | null } = {
+  destination: null,
+};
+
+export const actions = {
+  [`${cardPrefix}Init`]: assign(({ context }: { context: GameState }) =>
+    produce(context, (draft) => {
+      draft.commandBar = {
+        text: i18n.t("deck.policies.fishingGearRegulation.commandBarText"),
+      };
+    }),
+  ),
+  [`${cardPrefix}SetDestination`]: assign(({ context }: { context: GameState }, card: Card) =>
+    produce(context, (draft) => {
+      internalContext.destination = card;
+      draft.commandBar = undefined;
+    }),
+  ),
+  [`${cardPrefix}CardsToPlayerHand`]: assign(({ context }: { context: GameState }, card: Card) =>
+    produce(context, ({ animalMarket, plantMarket, players }) => {
+      const targetPlayer = players.find((player) => player.hand.some((handCard) => handCard.uid === card.uid));
+
+      if (!targetPlayer) return;
+
+      const mudAnimals = filter(context.animalMarket.table, (card) =>
+        card.habitats.some((habitatTile) => habitatTile === "mud"),
+      );
+      const mudPlants = filter(context.plantMarket.table, (card) =>
+        card.habitats.some((habitatTile) => habitatTile === "mud"),
+      );
+
+      animalMarket.table = without(context.animalMarket.table, ...mudAnimals);
+      const replacementAnimals = context.animalMarket.deck.slice(0, mudAnimals.length);
+      animalMarket.table = concat(animalMarket.table, replacementAnimals);
+      animalMarket.deck = without(context.animalMarket.deck, ...replacementAnimals);
+
+      plantMarket.table = without(context.plantMarket.table, ...mudPlants);
+      const replacementPlants = context.plantMarket.deck.slice(0, mudPlants.length);
+      plantMarket.table = concat(plantMarket.table, replacementPlants);
+      plantMarket.deck = without(context.plantMarket.deck, ...replacementPlants);
+
+      targetPlayer.hand = concat(targetPlayer.hand, [...mudAnimals, ...mudPlants]);
+    }),
+  ),
+  [`${cardPrefix}Done`]: assign(({ context }: { context: GameState }) =>
+    produce(context, (draft) => {
+      draft.stage = undefined;
+      draft.policyMarket.active = without(
+        context.policyMarket.active,
+        find(context.policyMarket.active, { name: cardName })!,
+      );
+      draft.policyMarket.table = without(
+        context.policyMarket.table,
+        find(context.policyMarket.table, { name: cardName })!,
+      );
+    }),
+  ),
+};
+
+export type GuardParams = ToParameterizedObject<typeof TurnMachineGuards>;
+export type ActionParams = ToParameterizedObject<typeof actions>;
+
+export const state: {
+  [cardPrefix]: ExpansionStateNodeConfig<ActionParams, GuardParams>;
+} = {
+  [cardPrefix]: {
+    tags: ["policy", cardPrefix],
+    initial: "pickingDestination",
+    states: {
+      pickingDestination: {
+        entry: `${cardPrefix}Init`,
+        on: {
+          "user.click.player.hand.card": {
+            target: "action",
+            actions: {
+              type: `${cardPrefix}SetDestination`,
+              params: ({ event }) => event.card,
+            },
+          },
+        },
+      },
+      action: {
+        entry: { type: `${cardPrefix}CardsToPlayerHand`, params: () => internalContext.destination! },
+        after: {
+          animationDuration: "done",
+        },
+      },
+      done: {
+        entry: [`${cardPrefix}Done`],
+        always: {
+          target: "#turn",
+        },
+      },
+    },
+  },
+};
+
+export const conditionCheck: ExpansionConditionConfig<ActionParams, GuardParams> = {
+  target: `#turn.${cardPrefix}`,
+  guard: {
+    type: "isPolicyCardActive",
+    params: cardName,
+  },
+};

--- a/src/state/machines/expansion/green_energy.ts
+++ b/src/state/machines/expansion/green_energy.ts
@@ -1,0 +1,120 @@
+import { GameState, HabitatName } from "@/state/types";
+import { produce } from "immer";
+import { concat, find, without } from "lodash";
+import { assign } from "@/state/machines/assign";
+import { ExpansionConditionConfig, ExpansionStateNodeConfig, ToParameterizedObject } from "@/lib/types";
+import { TurnMachineGuards } from "../guards";
+import { or } from "xstate";
+import i18n from "@/i18n";
+
+export const cardPrefix = "greenEnergy";
+export const cardName = "Green energy";
+
+export const uiStrings = {
+  [cardName]: {
+    name: i18n.t("deck.policies.greenEnergy.name"),
+    description: i18n.t("deck.policies.greenEnergy.description"),
+  },
+};
+
+export const actions = {
+  [`${cardPrefix}InitCommandBar`]: assign(({ context }: { context: GameState }) =>
+    produce(context, (draft) => {
+      draft.commandBar = {
+        text: i18n.t("deck.policies.greenEnergy.commandBarText"),
+      };
+    }),
+  ),
+  [`${cardPrefix}AddExtinctionTile`]: assign(({ context }: { context: GameState }) =>
+    produce(context, ({ extinctMarket }) => {
+      const extinctionTile = context.extinctMarket.deck.slice(0, 1);
+      extinctMarket.deck = without(context.extinctMarket.deck, ...extinctionTile);
+      extinctMarket.table = concat(context.extinctMarket.table, extinctionTile);
+    }),
+  ),
+  [`${cardPrefix}UnlockHabitat`]: assign(({ context }: { context: GameState }, name: HabitatName) =>
+    produce(context, (draft) => {
+      draft.commandBar = undefined;
+      draft.habitatMarket.deck.forEach((habitatTile) => {
+        if (habitatTile.name === name) habitatTile.isAcquired = true;
+      });
+    }),
+  ),
+  [`${cardPrefix}Done`]: assign(({ context }: { context: GameState }) =>
+    produce(context, (draft) => {
+      draft.stage = undefined;
+      draft.policyMarket.active = without(
+        context.policyMarket.active,
+        find(context.policyMarket.active, { name: cardName })!,
+      );
+      draft.policyMarket.table = without(
+        context.policyMarket.table,
+        find(context.policyMarket.table, { name: cardName })!,
+      );
+    }),
+  ),
+};
+
+export type GuardParams = ToParameterizedObject<typeof TurnMachineGuards>;
+export type ActionParams = ToParameterizedObject<typeof actions>;
+
+export const state: {
+  [cardPrefix]: ExpansionStateNodeConfig<ActionParams, GuardParams>;
+} = {
+  [cardPrefix]: {
+    tags: ["policy", cardPrefix],
+    initial: "initial",
+    states: {
+      initial: {
+        always: [
+          {
+            target: "addingExtinctionTile",
+            guard: or([
+              ({ context }) => TurnMachineGuards.habitatUnlocked({ context }, "mud"),
+              ({ context }) => TurnMachineGuards.habitatUnlocked({ context }, "rock"),
+              ({ context }) => TurnMachineGuards.habitatUnlocked({ context }, "coast"),
+            ]),
+          },
+          {
+            target: "pickingTarget",
+          },
+        ],
+      },
+      addingExtinctionTile: {
+        entry: `${cardPrefix}AddExtinctionTile`,
+        always: "done",
+      },
+      pickingTarget: {
+        entry: `${cardPrefix}InitCommandBar`,
+        on: {
+          "user.click.market.deck.habitat": {
+            target: "done",
+            actions: {
+              type: `${cardPrefix}UnlockHabitat`,
+              params: ({ event }) => event.name,
+            },
+            guard: or([
+              ({ event }) => event.name === "rock",
+              ({ event }) => event.name === "mud",
+              ({ event }) => event.name === "coast",
+            ]),
+          },
+        },
+      },
+      done: {
+        entry: [`${cardPrefix}Done`],
+        always: {
+          target: "#turn",
+        },
+      },
+    },
+  },
+};
+
+export const conditionCheck: ExpansionConditionConfig<ActionParams, GuardParams> = {
+  target: `#turn.${cardPrefix}`,
+  guard: {
+    type: "isPolicyCardActive",
+    params: cardName,
+  },
+};

--- a/src/state/machines/expansion/index.ts
+++ b/src/state/machines/expansion/index.ts
@@ -14,6 +14,10 @@ import * as NutrientUpwelling from "./nutrient_upwelling";
 import * as ExcessiveFertilizerUse from "./excessive_fertilizer_use";
 import * as UpgradedWasteWaterTreatment from "./upgraded_waste_water_treatment";
 import * as ImprovedNutrientRetention from "./improved_nutrient_retention";
+import * as MigratoryBarrierRemoval from "./migratory_barrier_removal";
+import * as FishingGearRegulation from "./fishing_gear_regulation";
+import * as RecyclingAndWasteDisposal from "./recycling_and_waste_disposal";
+import * as GreenEnergy from "./green_energy";
 import { ExpansionActionFunctionMap } from "@/lib/types";
 import i18n from "@/i18n";
 
@@ -34,6 +38,10 @@ export const names = [
   ExcessiveFertilizerUse.cardName,
   UpgradedWasteWaterTreatment.cardName,
   ImprovedNutrientRetention.cardName,
+  MigratoryBarrierRemoval.cardName,
+  FishingGearRegulation.cardName,
+  RecyclingAndWasteDisposal.cardName,
+  GreenEnergy.cardName,
 ] as const;
 
 export const uiStrings = {
@@ -53,6 +61,10 @@ export const uiStrings = {
   ...ExcessiveFertilizerUse.uiStrings,
   ...UpgradedWasteWaterTreatment.uiStrings,
   ...ImprovedNutrientRetention.uiStrings,
+  ...MigratoryBarrierRemoval.uiStrings,
+  ...FishingGearRegulation.uiStrings,
+  ...RecyclingAndWasteDisposal.uiStrings,
+  ...GreenEnergy.uiStrings,
 };
 
 export const expansionActions = {
@@ -71,6 +83,10 @@ export const expansionActions = {
   ...ExcessiveFertilizerUse.actions,
   ...UpgradedWasteWaterTreatment.actions,
   ...ImprovedNutrientRetention.actions,
+  ...MigratoryBarrierRemoval.actions,
+  ...FishingGearRegulation.actions,
+  ...RecyclingAndWasteDisposal.actions,
+  ...GreenEnergy.actions,
 } as ExpansionActionFunctionMap;
 
 export const expansionState = {
@@ -89,6 +105,10 @@ export const expansionState = {
   ...ExcessiveFertilizerUse.state,
   ...UpgradedWasteWaterTreatment.state,
   ...ImprovedNutrientRetention.state,
+  ...MigratoryBarrierRemoval.state,
+  ...FishingGearRegulation.state,
+  ...RecyclingAndWasteDisposal.state,
+  ...GreenEnergy.state,
 };
 
 export const expansionConditionChecks = [
@@ -106,6 +126,10 @@ export const expansionConditionChecks = [
   ExcessiveFertilizerUse.conditionCheck,
   UpgradedWasteWaterTreatment.conditionCheck,
   ImprovedNutrientRetention.conditionCheck,
+  MigratoryBarrierRemoval.conditionCheck,
+  FishingGearRegulation.conditionCheck,
+  RecyclingAndWasteDisposal.conditionCheck,
+  GreenEnergy.conditionCheck,
 ];
 
 export const expansionStageEventText = {

--- a/src/state/machines/expansion/migratory_barrier_removal.ts
+++ b/src/state/machines/expansion/migratory_barrier_removal.ts
@@ -26,7 +26,7 @@ export const actions = {
   [`${cardPrefix}Init`]: assign(({ context }: { context: GameState }) =>
     produce(context, (draft) => {
       draft.commandBar = {
-        text: i18n.t("deck.policies.migratoryBarrierRemoval.targetCommandBarText"),
+        text: i18n.t("deck.policies.migratoryBarrierRemoval.pickSpeciesCommandBarText"),
       };
     }),
   ),
@@ -34,7 +34,7 @@ export const actions = {
     produce(context, (draft) => {
       internalContext.target = card;
       draft.commandBar = {
-        text: i18n.t("deck.policies.migratoryBarrierRemoval.destinationCommandBarText"),
+        text: i18n.t("deck.policies.migratoryBarrierRemoval.pickPlayerCommandBarText"),
       };
     }),
   ),

--- a/src/state/machines/expansion/migratory_barrier_removal.ts
+++ b/src/state/machines/expansion/migratory_barrier_removal.ts
@@ -1,0 +1,133 @@
+import { AnimalCard, Card, GameState } from "@/state/types";
+import { produce } from "immer";
+import { concat, find, without } from "lodash";
+import { assign } from "@/state/machines/assign";
+import { ExpansionConditionConfig, ExpansionStateNodeConfig, ToParameterizedObject } from "@/lib/types";
+import { TurnMachineGuards } from "../guards";
+import { or } from "xstate";
+import i18n from "@/i18n";
+
+export const cardPrefix = "migratoryBarrierRemoval";
+export const cardName = "Migratory barrier removal";
+
+export const uiStrings = {
+  [cardName]: {
+    name: i18n.t("deck.policies.migratoryBarrierRemoval.name"),
+    description: i18n.t("deck.policies.migratoryBarrierRemoval.description"),
+  },
+};
+
+const internalContext: { target: AnimalCard | null; destination: Card | null } = {
+  target: null,
+  destination: null,
+};
+
+export const actions = {
+  [`${cardPrefix}Init`]: assign(({ context }: { context: GameState }) =>
+    produce(context, (draft) => {
+      draft.commandBar = {
+        text: i18n.t("deck.policies.migratoryBarrierRemoval.targetCommandBarText"),
+      };
+    }),
+  ),
+  [`${cardPrefix}SetTarget`]: assign(({ context }: { context: GameState }, card: AnimalCard) =>
+    produce(context, (draft) => {
+      internalContext.target = card;
+      draft.commandBar = {
+        text: i18n.t("deck.policies.migratoryBarrierRemoval.destinationCommandBarText"),
+      };
+    }),
+  ),
+  [`${cardPrefix}SetDestination`]: assign(({ context }: { context: GameState }, card: Card) =>
+    produce(context, (draft) => {
+      internalContext.destination = card;
+      draft.commandBar = undefined;
+    }),
+  ),
+  [`${cardPrefix}CardToPlayerHand`]: assign(({ context }: { context: GameState }, card: Card) =>
+    produce(context, ({ animalMarket, players }) => {
+      const targetPlayer = players.find((player) => player.hand.some((handCard) => handCard.uid === card.uid));
+
+      if (!targetPlayer || internalContext.target === null) return;
+
+      animalMarket.table = without(context.animalMarket.table, internalContext.target);
+      animalMarket.table = concat(animalMarket.table, context.animalMarket.deck[0]);
+      animalMarket.deck = without(context.animalMarket.deck, context.animalMarket.deck[0]);
+      targetPlayer.hand.push(internalContext.target);
+    }),
+  ),
+  [`${cardPrefix}Done`]: assign(({ context }: { context: GameState }) =>
+    produce(context, (draft) => {
+      draft.stage = undefined;
+      draft.policyMarket.active = without(
+        context.policyMarket.active,
+        find(context.policyMarket.active, { name: cardName })!,
+      );
+      draft.policyMarket.table = without(
+        context.policyMarket.table,
+        find(context.policyMarket.table, { name: cardName })!,
+      );
+    }),
+  ),
+};
+
+export type GuardParams = ToParameterizedObject<typeof TurnMachineGuards>;
+export type ActionParams = ToParameterizedObject<typeof actions>;
+
+export const state: {
+  [cardPrefix]: ExpansionStateNodeConfig<ActionParams, GuardParams>;
+} = {
+  [cardPrefix]: {
+    tags: ["policy", cardPrefix],
+    initial: "pickingTarget",
+    states: {
+      pickingTarget: {
+        entry: `${cardPrefix}Init`,
+        on: {
+          "user.click.market.table.card": {
+            target: "pickingDestination",
+            actions: {
+              type: `${cardPrefix}SetTarget`,
+              params: ({ event }) => event.card as AnimalCard,
+            },
+            guard: or([
+              ({ context, event }) => TurnMachineGuards.isBirdCard({ context }, event.card),
+              ({ context, event }) => TurnMachineGuards.isFishCard({ context }, event.card),
+            ]),
+          },
+        },
+      },
+      pickingDestination: {
+        on: {
+          "user.click.player.hand.card": {
+            target: "action",
+            actions: {
+              type: `${cardPrefix}SetDestination`,
+              params: ({ event }) => event.card,
+            },
+          },
+        },
+      },
+      action: {
+        entry: { type: `${cardPrefix}CardToPlayerHand`, params: () => internalContext.destination! },
+        after: {
+          animationDuration: "done",
+        },
+      },
+      done: {
+        entry: [`${cardPrefix}Done`],
+        always: {
+          target: "#turn",
+        },
+      },
+    },
+  },
+};
+
+export const conditionCheck: ExpansionConditionConfig<ActionParams, GuardParams> = {
+  target: `#turn.${cardPrefix}`,
+  guard: {
+    type: "isPolicyCardActive",
+    params: cardName,
+  },
+};

--- a/src/state/machines/expansion/recycling_and_waste_disposal.ts
+++ b/src/state/machines/expansion/recycling_and_waste_disposal.ts
@@ -1,0 +1,139 @@
+import { DisasterCard, GameState } from "@/state/types";
+import { produce } from "immer";
+import { concat, find, without } from "lodash";
+import { assign } from "@/state/machines/assign";
+import { ExpansionConditionConfig, ExpansionStateNodeConfig, ToParameterizedObject } from "@/lib/types";
+import { TurnMachineGuards } from "../guards";
+import i18n from "@/i18n";
+import { and } from "xstate";
+import { shuffle } from "@/state/utils";
+
+export const cardPrefix = "recyclingAndWasteDisposal";
+export const cardName = "Recycling and waste disposal";
+
+export const uiStrings = {
+  [cardName]: {
+    name: i18n.t("deck.policies.recyclingAndWasteDisposal.name"),
+    description: i18n.t("deck.policies.recyclingAndWasteDisposal.description"),
+  },
+};
+
+const internalContext: { target: DisasterCard | null; numberOfCardsTransferred: number } = {
+  numberOfCardsTransferred: 0,
+  target: null,
+};
+
+export const actions = {
+  [`${cardPrefix}Init`]: () => {
+    internalContext.numberOfCardsTransferred = 0;
+  },
+  [`${cardPrefix}InitCommandBar`]: assign(({ context }: { context: GameState }) =>
+    produce(context, (draft) => {
+      draft.commandBar = {
+        text: i18n.t("deck.policies.recyclingAndWasteDisposal.commandBarText"),
+      };
+    }),
+  ),
+  [`${cardPrefix}SetTarget`]: assign(({ context }: { context: GameState }, card: DisasterCard) =>
+    produce(context, (draft) => {
+      internalContext.target = card;
+      draft.commandBar = undefined;
+    }),
+  ),
+  [`${cardPrefix}RemoveDisasterCard`]: assign(({ context }: { context: GameState }) =>
+    produce(context, ({ players }) => {
+      if (internalContext.target === null) return;
+
+      const targetPlayer = players.find((player) =>
+        player.hand.some((handCard) => handCard.uid === internalContext.target!.uid),
+      );
+
+      if (!targetPlayer) return;
+
+      if (targetPlayer.deck.length === 0) {
+        targetPlayer.deck = shuffle(targetPlayer.discard, context.config.seed);
+        targetPlayer.discard = [];
+      }
+
+      targetPlayer.hand = without(targetPlayer.hand, find(targetPlayer.hand, { uid: internalContext.target.uid })!);
+      targetPlayer.hand = concat(targetPlayer.hand, targetPlayer.deck.slice(0, 1));
+      targetPlayer.deck = targetPlayer.deck.slice(1);
+
+      internalContext.numberOfCardsTransferred += 1;
+      internalContext.target = null;
+    }),
+  ),
+  [`${cardPrefix}Done`]: assign(({ context }: { context: GameState }) =>
+    produce(context, (draft) => {
+      draft.stage = undefined;
+      draft.policyMarket.active = without(
+        context.policyMarket.active,
+        find(context.policyMarket.active, { name: cardName })!,
+      );
+      draft.policyMarket.table = without(
+        context.policyMarket.table,
+        find(context.policyMarket.table, { name: cardName })!,
+      );
+    }),
+  ),
+};
+
+export type GuardParams = ToParameterizedObject<typeof TurnMachineGuards>;
+export type ActionParams = ToParameterizedObject<typeof actions>;
+
+export const state: {
+  [cardPrefix]: ExpansionStateNodeConfig<ActionParams, GuardParams>;
+} = {
+  [cardPrefix]: {
+    tags: ["policy", cardPrefix],
+    entry: `${cardPrefix}Init`,
+    initial: "initial",
+    states: {
+      initial: {
+        always: [
+          {
+            target: "pickingTarget",
+            guard: and([
+              () => internalContext.numberOfCardsTransferred < 2,
+              ({ context }) => TurnMachineGuards.playerHasDisasterCardInHand({ context }),
+            ]),
+          },
+          { target: "done" },
+        ],
+      },
+      pickingTarget: {
+        entry: `${cardPrefix}InitCommandBar`,
+        on: {
+          "user.click.player.hand.card": {
+            target: "action",
+            actions: {
+              type: `${cardPrefix}SetTarget`,
+              params: ({ event }) => event.card as DisasterCard,
+            },
+            guard: { type: "isDisasterCard", params: ({ event }) => event.card },
+          },
+        },
+      },
+      action: {
+        entry: { type: `${cardPrefix}RemoveDisasterCard`, params: () => internalContext.target! },
+        after: {
+          animationDuration: "initial",
+        },
+      },
+      done: {
+        entry: [`${cardPrefix}Done`],
+        always: {
+          target: "#turn",
+        },
+      },
+    },
+  },
+};
+
+export const conditionCheck: ExpansionConditionConfig<ActionParams, GuardParams> = {
+  target: `#turn.${cardPrefix}`,
+  guard: {
+    type: "isPolicyCardActive",
+    params: cardName,
+  },
+};

--- a/src/state/machines/guards.ts
+++ b/src/state/machines/guards.ts
@@ -1,4 +1,4 @@
-import { AbilityTile, AnimalCard, Card, CardType, GameState, PlantCard } from "@/state/types";
+import { AbilityTile, AnimalCard, Card, CardType, GameState, HabitatName, PlantCard } from "@/state/types";
 import { countBy, find, compact, every, intersection, isEmpty } from "lodash";
 import { getAnimalHabitatPairs, getDuplicateElements } from "./helpers/turn";
 import { Tail } from "../../lib/types";
@@ -243,6 +243,14 @@ export const TurnMachineGuards = {
 
   isAnimalCard: ({ context: _ }: { context: GameState }, card: Card) => card.type === "animal",
 
+  isDisasterCard: ({ context: _ }: { context: GameState }, card: Card) => card.type === "disaster",
+
+  isBirdCard: ({ context: _ }: { context: GameState }, card: Card) =>
+    card.type === "animal" && card.faunaType === "bird",
+
+  isFishCard: ({ context: _ }: { context: GameState }, card: Card) =>
+    card.type === "animal" && card.faunaType === "fish",
+
   hasSharedHabitatInHand: ({ context }: { context: GameState }, card: PlantCard) => {
     const player = find(context.players, { uid: context.turn.player })!;
 
@@ -262,6 +270,12 @@ export const TurnMachineGuards = {
     context.policyMarket.active.some((policyCard) => policyCard.name === policyCardName),
 
   isSinglePlayer: ({ context: { players } }: { context: GameState }) => players.length === 1,
+
+  playerHasDisasterCardInHand: ({ context: { players } }: { context: GameState }) =>
+    players.some((player) => player.hand.some((card) => card.type === "disaster")),
+
+  habitatUnlocked: ({ context: { habitatMarket } }: { context: GameState }, habitatName: HabitatName) =>
+    find(habitatMarket.deck, { name: habitatName })?.isAcquired ?? false,
 };
 
 export type ContextInjectedGuardMap = {

--- a/src/state/machines/turn.ts
+++ b/src/state/machines/turn.ts
@@ -13,6 +13,7 @@ import {
   AbilityName,
   isAbilityUID,
   PolicyCard,
+  HabitatName,
 } from "@/state/types";
 import { assign } from "@/state/machines/assign";
 import { DeckConfig } from "@/decks/schema";
@@ -49,6 +50,7 @@ export type TurnMachineEvent =
   | { type: "user.click.player.endTurn" }
   | { type: "user.click.token"; token: AbilityTile }
   | { type: "user.click.player.hand.card"; card: Card }
+  | { type: "user.click.market.deck.habitat"; name: HabitatName }
   | { type: "user.click.market.deck.element"; name: ElementCard["name"] }
   | { type: "user.click.market.borrowed.card.element"; card: ElementCard }
   | { type: "user.click.market.table.card"; card: PlantCard | AnimalCard }

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -219,7 +219,17 @@ export interface AnimalCard extends GamePieceBase {
 }
 
 export type PolicyEffect = "positive" | "negative" | "dual" | "implementation";
-export type PolicyTheme = "hazard" | "eutro" | "climateChange" | "extractionOfSpecies" | "restore" | "noise" | "N/A";
+export type PolicyTheme =
+  | "hazard"
+  | "eutro"
+  | "climateChange"
+  | "extractionOfSpecies"
+  | "restore"
+  | "noise"
+  | "fishing"
+  | "litter"
+  | "msp"
+  | "N/A";
 export type PolicyUsage = "single" | "permanent";
 
 export interface PolicyCard extends GamePieceBase {


### PR DESCRIPTION
This PR adds 4 new expansion cards that use the command bar to instruct the user

`Name`: Migratory barrier removal
`Effect`: Positive
`Theme`: Restore
`Usage`: Single
`Description`: Take one fish or bird card from the market and add to any players hand.

`Name`: Fishing gear regulation
`Effect`: Positive
`Theme`: Fishing
`Usage`: Single
`Description`: Add all cards in the market which have a soft benthic symbol to any players hand.

`Name`: Recycling and waste disposal
`Effect`: Positive
`Theme`: Litter
`Usage`: Single
`Description`: Remove two human activity cards from the hand(s) of any player(s) and replace the cards with cards from the player(s) deck(s).

`Name`: Green energy
`Effect`: Dual
`Theme`: MSP
`Usage`: Single
`Description`: If coastal, hard- or soft bottom habitats have already been restored when this card is lifted, add an impact tile. If none of the above habitats have been restored prior to lifting this card, choose one of these habitats to immediately restore.